### PR TITLE
sourcemap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 jsdom-eval
 ==========
 
-eval js inside jsdom for simple testing that requires the dom
+eval js inside jsdom for simple testing that requires the dom.
+if there are uncought exceptions jsdom-eval will print the trace
+along with a snippet showing where the error was thrown
+
+sourcemaps are supports, for both stacktraces and the snippet.
 
 ## Usage
 `jsdom-eval ./my.js --html ./optional.html`
@@ -13,7 +17,7 @@ or
 
 ## run tape tests in jsdom
 
-`browserify ./my_tape_test.js | jsdom-eval | faucet`
+`browserify ./my_tape_test.js -d | jsdom-eval | faucet`
 
 ## API
 

--- a/cli.js
+++ b/cli.js
@@ -49,14 +49,14 @@ function run() {
 function on_error(err) {
   var original = err.originalLocation
 
-  if(!original || !original.content) {
+  if(!original || !original.sourceContent) {
     console.error(err.stack)
     process.exit(1)
   }
 
 
   var first = Math.max(original.line - 5, 0)
-  var snipet = original.content.slice(first, 11)
+  var snipet = original.sourceContent.slice(first, 11)
 
   snipet.splice(
       original.line - first
@@ -64,7 +64,7 @@ function on_error(err) {
     , new Array(original.column + 1).join(' ') + '^'
   )
 
+  console.error(err.stack + '\n\n')
   console.error(snipet.join('\n'))
-  console.error(err.stack)
   process.exit(1)
 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ function run(script, html, done) {
       , column: +parts[3]
     })
 
-    original.content = sourcemap.sourceContentFor(original.source).split('\n')
+    original.sourceContent = sourcemap.sourceContentFor(original.source)
+      .split('\n')
 
     return original
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "concat-stream": "^1.4.6",
     "convert-source-map": "^0.3.5",
-    "jsdom": "tmpvar/jsdom",
+    "jsdom": "git://github.com/tmpvar/jsdom/#049a52330576f877e526d2dfc84c5b651f4e684c",
     "minimist": "^0.1.0",
     "source-map": "^0.1.37"
   }


### PR DESCRIPTION
example output:

will output the 5 lines before and after the error location. and update stack traces with correct locations

```
ReferenceError: a is not defined
    at fail [as _onTimeout] (/Users/michaelhayes/work/jsdom-eval/test.js:6:0)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)


setTimeout(fail, 1000)

function fail() {
  console.log(a)
^
}
```
