### PR TITLE
revert to original stack trace in case of failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ function run(script, html) {
     }
 
     originalPrepareStackTrace = window.Error.prepareStackTrace
-    window.Error.prepareStackTrace = prepareStackTrace
     Object.keys(console).forEach(function(name) {
       if(typeof console[name] === 'function') {
         window.console[name] = console[name].bind(console)


### PR DESCRIPTION
So it turns out this function fails sometimes. I encoutnered it while
converting urbanairship's js tests from drive to tape + jsdom-eval + sinon. It
looks like one of these calls: https://github.com/AWinterman/jsdom-eval/blob/master/index.js#L42-L43
involves a method lookup against undefined. I'm not sure under which conditions
this happens, and can continue to investigate if needed.

Sorry this is a bit of hammer, but i don't think this method should EVER be allowed to throw.
